### PR TITLE
Update release links to point to the tag latest

### DIFF
--- a/doc/big-data-analysis-of-historic-context-information/deep-dive.md
+++ b/doc/big-data-analysis-of-historic-context-information/deep-dive.md
@@ -4,8 +4,8 @@ Should you wish to learn much more about this, please check:
        - [Github repository (reference implementation)](https://github.com/Fiware/context.Cygnus)
        - [Play with the Docker container](https://hub.docker.com/r/fiware/cygnus/)
        - [Read the full documentation](http://fiware-cygnus.readthedocs.org/en/latest/)
-       - [Latest stable release](https://github.com/Fiware/context.Cygnus/releases/tag/release-0.12.0)
+       - [Latest stable release](https://github.com/telefonicaid/fiware-cygnus/releases/latest)
    - Cosmos:
        - [Github repository (reference implementation)](https://github.com/Fiware/context.Cosmos)
        - [Read the full documentation](http://fiware-cosmos.readthedocs.org/en/latest/)
-       - [Latest stable release](https://github.com/Fiware/context.Cosmos/releases/tag/release-0.2.0)
+       - [Latest stable release](https://github.com/telefonicaid/fiware-cosmos/releases/latest)

--- a/doc/connection-to-the-internet-of-things/deep-dive.md
+++ b/doc/connection-to-the-internet-of-things/deep-dive.md
@@ -4,5 +4,5 @@ Should you wish to learn much more about this, please check:
    - [Play with the Docker container](https://hub.docker.com/r/fiware/fiware-iotagent-cplusplus/)
    - [Browse the API](http://docs.telefonicaiotiotagents.apiary.io)
    - [Read the full documentation](http://fiware-iot-stack.readthedocs.org/en/latest/)
-   - [Latest stable release](https://github.com/Fiware/iot.IoTAgent-Cplusplus/releases/tag/1.3.0%2FKO)
+   - [Latest stable release](https://github.com/telefonicaid/fiware-IoTAgent-Cplusplus/releases/latest)
 

--- a/doc/creating-application-dashboards/deep-dive.md
+++ b/doc/creating-application-dashboards/deep-dive.md
@@ -4,4 +4,4 @@ Should you wish to learn much more about this, please check:
    - [Play with the Docker container](https://hub.docker.com/r/fiware/wirecloud/)
    - [Browse the API](http://docs.fiwareapplicationmashup.apiary.io)
    - [Read the full documentation](http://wirecloud.readthedocs.org/en/latest/)
-   - [Latest stable release](https://github.com/Fiware/apps.Wirecloud/releases/tag/0.9.0)
+   - [Latest stable release](https://github.com/Wirecloud/wirecloud/releases/latest)

--- a/doc/handling-authorization-and-access-control-to-apis/deep-dive.md
+++ b/doc/handling-authorization-and-access-control-to-apis/deep-dive.md
@@ -5,14 +5,14 @@ Should you wish to learn much more about this, please check:
        - [Play with the Docker container](https://hub.docker.com/r/fiware/idm/)
        - [Browse the API](http://docs.keyrock.apiary.io/)
        - [Read the full documentation](http://fiware-idm.readthedocs.org/en/latest/)
-       - [Latest stable release](https://github.com/Fiware/security.Idm/releases/tag/v5.1.1)
+       - [Latest stable release](https://github.com/ging/fiware-idm/releases/latest)
    - AuthzForce
        - [Github repository (reference implementation)](https://github.com/Fiware/security.AuthZForce)
        - [Play with the Docker container](https://hub.docker.com/r/fiware/authzforce-ce-server/)
        - [Read the full documentation](http://authzforce-ce-fiware.readthedocs.org/en/latest/)
-       - [Latest stable release](https://github.com/authzforce/server/releases/tag/release-4.4.0)
+       - [Latest stable release](https://github.com/authzforce/server/releases/latest)
    - Pep-proxy
        - [Github repository (reference implementation)](https://github.com/Fiware/security.Pep-proxy)
        - [Play with the Docker container](https://hub.docker.com/r/fiware/pep-proxy/)
        - [Read the full documentation](http://fiware-pep-proxy.readthedocs.org/en/stable/)
-       - [Latest stable release](https://github.com/Fiware/security.Pep-proxy/releases/tag/5.1)
+       - [Latest stable release](https://github.com/ging/fiware-pep-proxy/releases/latest)

--- a/doc/providing-an-advanced-user-experience-ux/deep-dive.md
+++ b/doc/providing-an-advanced-user-experience-ux/deep-dive.md
@@ -3,18 +3,18 @@ Should you wish to learn much more about this, please check:
    - XML3D:
       - [Github repository (reference implementation)](https://github.com/Fiware/webui.XML3D)
       - [Read the full documentation](https://xml3d.readthedocs.org/en/latest)
-      - [Latest stable release](https://github.com/Fiware/webui.XML3D/releases/tag/5.1.4) 
+      - [Latest stable release](https://github.com/xml3d/xml3d.js/releases/latest) 
 
    - webtundra: 
       - [Github repository (reference implementation)](https://github.com/Fiware/webui.WebTundra3D)
       - [Play with the Docker container](https://hub.docker.com/r/adminotech/webtundra/)
       - [Read the full documentation](http://webtundra.readthedocs.org/en/latest/)
-      - [Latest stable release](https://github.com/Fiware/webui.WebTundra3D/releases/tag/5.1.3) 
+      - [Latest stable release](https://github.com/realXtend/WebTundra/releases/latest) 
    
    - POI Data Provider: 
       - [Github repository (reference implementation)](https://github.com/Fiware/webui.POIDataProvider)
       - [Play with the Docker container](https://hub.docker.com/r/ariokkon/fiware_poi_dataprovider/)
-      - [Latest stable release](https://github.com/Fiware/webui.POIDataProvider/releases/tag/r5.1)    
+      - [Latest stable release](https://github.com/Chiru/FIWARE-POIDataProvider/releases/latest)    
 
    - Synchronization: 
       - Tundra version:
@@ -22,13 +22,13 @@ Should you wish to learn much more about this, please check:
          - [Play with the Docker container](https://hub.docker.com/r/loorni/synchronization/)
          - [Browse the API](http://docs.sceneapi.apiary.io/)
          - [Read the full documentation](http://synchronization.readthedocs.org/en/latest/)
-         - [Latest stable release](https://github.com/Fiware/webui.Synchronization.Tundra/releases/tag/tundra2.5.4) 
+         - [Latest stable release](https://github.com/realXtend/tundra/releases/latest) 
       - FiVES version:
          - [Github repository (reference implementation)](https://github.com/Fiware/webui.Synchronization.FivES)
          - [Play with the Docker container](https://hub.docker.com/r/tospie/fives/)
          - [Browse the API](http://docs.sceneapi.apiary.io/)
          - [Read the full documentation](http://fives.readthedocs.org/en/latest/ )
-         - [Latest stable release](https://github.com/Fiware/webui.Synchronization.FivES/releases/tag/fiware-4.4.1) 
+         - [Latest stable release](https://github.com/fives-team/FiVES/releases/latest) 
 
 
 

--- a/doc/publishing-open-data-in-fiware/deep-dive.md
+++ b/doc/publishing-open-data-in-fiware/deep-dive.md
@@ -4,4 +4,4 @@ Should you wish to learn much more about this, please check:
    - [Play with the Docker container](https://hub.docker.com/r/fiware/ckan/)
    - [Browse the API](http://docs.ckan.apiary.io/)
    - [Read the full documentation](http://docs.ckan.org/en/latest/)
-   - [Latest stable release](https://github.com/Fiware/context.Ckan/releases/tag/ckan-2.5.2)
+   - [Latest stable release](https://github.com/ckan/ckan/releases/latest)

--- a/doc/real-time-processing-of-context-events/deep-dive.md
+++ b/doc/real-time-processing-of-context-events/deep-dive.md
@@ -3,4 +3,4 @@ Should you wish to learn much more about this, please check:
    - [Github repository (reference implementation)](https://github.com/Fiware/context.Proton)
    - [Play with the Docker container](https://hub.docker.com/r/fiware/proactivetechnologyonline/)
    - [Read the full documentation](http://proactive-technology-online.readthedocs.org/en/latest/)
-   - [Latest stable release](https://github.com/Fiware/context.Proton/releases/tag/v4.4.1)
+   - [Latest stable release](https://github.com/ishkin/Proton/releases/latest)

--- a/doc/real-time-processing-of-media-streams/deep-dive.md
+++ b/doc/real-time-processing-of-media-streams/deep-dive.md
@@ -4,5 +4,5 @@ Should you wish to learn much more about this, please check:
    - [Play with the Docker container](https://hub.docker.com/r/fiware/stream-oriented-kurento/)
    - [Browse the API](http://docs.streamoriented.apiary.io/)
    - [Read the full documentation](http://kurento.readthedocs.org/en/latest/)
-   - [Latest stable release](https://github.com/Kurento/kurento-media-server/releases/tag/6.4.0)
+   - [Latest stable release](https://github.com/Kurento/kurento-media-server/releases/latest)
 


### PR DESCRIPTION
This PR updates the links named **Latest stable release** inside the deep dive section. Please, take into account that in order to use the latest tag we should point to the original repositories instead of the mirrored one.

Although all the links are update, these links were found to not have defined the tag _latest_:
- https://github.com/ishkin/Proton/releases/latest
- https://github.com/ckan/ckan/releases/latest
- https://github.com/Kurento/kurento-media-server/releases/latest
- https://github.com/realXtend/tundra/releases/latest
