### PR TITLE
Added the explanation abou the 'Fiware-service: tourguide' header

### DIFF
--- a/doc/development-context-aware-applications/how-to-connect-to-external-context-providers.md
+++ b/doc/development-context-aware-applications/how-to-connect-to-external-context-providers.md
@@ -31,6 +31,16 @@ Provider.
 First, the Context Provider is registered as provider of `occupancyLevels` for Elizalde restaurant which id is `0115206c51f60b48b77e4c937835795c33bb953f`:
 
     POST <cb_host>:<cb_port>/v1/registry/contextEntities/type/Restaurant/id/0115206c51f60b48b77e4c937835795c33bb953f/attributes/occupancyLevels
+        
+    Headers:
+
+    {
+      'Content-Type':     'application/json',
+      'Fiware-Service':   'tourguide'
+    }
+
+    Payload:
+
     {
       "duration" : "P1M",
       "providingApplication" : "http://booking.restaurants.foo.com"

--- a/doc/development-context-aware-applications/how-to-perform-geo-located-queries.md
+++ b/doc/development-context-aware-applications/how-to-perform-geo-located-queries.md
@@ -6,6 +6,16 @@ Vitoria-Gasteiz city center (identified by GPS coordinates 42.846718, -2.671635)
 a Context Consumer application will use the following query:
 
     POST <cb_host>:<cb_port>/v1/queryContext
+        
+    Headers:
+
+    {
+      'Content-Type':     'application/json',
+      'Fiware-Service':   'tourguide'
+    }
+
+    Payload:
+
     {
       "entities": [
         {
@@ -31,11 +41,19 @@ a Context Consumer application will use the following query:
     }
 
 
-
 To query for all restaurants inside a defined zone inside Vitoria-Gasteiz city a Context Consumer application will use the following query: 
 
-
     POST <cb_host>:<cb_port>/v1/queryContext
+        
+    Headers:
+
+    {
+      'Content-Type':     'application/json',
+      'Fiware-Service':   'tourguide'
+    }
+
+    Payload:
+
     {
       "entities": [
         {

--- a/doc/development-context-aware-applications/how-to-subscribe-to-changes-on-context-information.md
+++ b/doc/development-context-aware-applications/how-to-subscribe-to-changes-on-context-information.md
@@ -11,6 +11,16 @@ gets notified (in order to recalculate restaurant average score and
 publish it back in the Context Broker GE).
 
     POST <cb_host>:<cb_port>/v1/subscribeContext
+        
+    Headers:
+
+    {
+      'Content-Type':     'application/json',
+      'Fiware-Service':   'tourguide'
+    }
+
+    Payload:
+
     {
       "entities": [
         {
@@ -37,6 +47,16 @@ average ratings of a given restaurant. This may be useful for restaurant
 owners in order to know how their restaurants score is evolving. In this example a subscription to the restaurant Elizalde which id is `0115206c51f60b48b77e4c937835795c33bb953f` is performed:
   
     POST <cb_host>:<cb_port>/v1/subscribeContext
+        
+    Headers:
+
+    {
+      'Content-Type':     'application/json',
+      'Fiware-Service':   'tourguide'
+    }
+
+    Payload:
+
     {
       "entities": [
         {

--- a/doc/development-context-aware-applications/how-to-update-and-query-context-information.md
+++ b/doc/development-context-aware-applications/how-to-update-and-query-context-information.md
@@ -25,6 +25,16 @@ Context Producer role **creating** a Review entity by issuing the
 following HTTP request:
 
     POST <cb_host>:<cb_port>/v1/contextEntities/type/Review/id/review-Elizalde-34
+    
+    Headers:
+
+    {
+      'Content-Type':     'application/json',
+      'Fiware-Service':   'tourguide'
+    }
+
+    Payload:
+
     {
       "attributes":
       [
@@ -62,16 +72,28 @@ which (playing also the role of Context Producer) **updates** the
 Restaurant entity accordingly. For this example the user has reviewed the Elizalde restaurant:
 
     PUT <cb_host>:<cb_port>/v1/contextEntities/type/Restaurant/id/0115206c51f60b48b77e4c937835795c33bb953f/attributes/aggregateRating
+
+    Headers:
+
+    {
+      'Content-Type':     'application/json',
+      'Fiware-Service':   'tourguide'
+    }
+
+    Payload:
+
     {
       "value" : 4,
       "reviewCount": 1
     }
 
+
+
 Finally, the user can get the information of a given Restaurant using
 the smartphone application. In that case the application works as
 Context Consumer, **querying** the Restaurant entity. For example, to get
 the aggregateRating attribute, the client application could query for
-it in the following way:
+it in the following way (with extra headers `Fiware-Service: tourguide`):
 
     GET <cb_host>:<cb_port>/v1/contextEntities/type/Restaurant/id/0115206c51f60b48b77e4c937835795c33bb953f/attributes/aggregateRating    
     
@@ -94,7 +116,7 @@ it in the following way:
 
 
 You can also obtain the values of all attributes of the "Elizalde"
-restaurant in a single shot:
+restaurant in a single shot (with extra headers `Fiware-Service: tourguide`):
 
 
     GET <cb_host>:<cb_port>/v1/contextEntities/type/Restaurant/id/0115206c51f60b48b77e4c937835795c33bb953f
@@ -182,7 +204,7 @@ restaurant in a single shot:
 
 Alternatively, if you want to get the **attributes as a key map instead
 of as a vector**, you can use the `attributesFormat` parameter, in the
-following way:
+following way (with extra headers `Fiware-Service: tourguide`):
 
     GET <cb_host>:<cb_port>/v1/contextEntities/type/Restaurant/id/0115206c51f60b48b77e4c937835795c33bb953f?attributesFormat=object    
     

--- a/doc/development-context-aware-applications/v2/how-to-perform-geo-located-queries.md
+++ b/doc/development-context-aware-applications/v2/how-to-perform-geo-located-queries.md
@@ -9,6 +9,7 @@ geo-located queries. You can query entities using the following spatial relation
  * `georel=equals`: equality to a geometry.
  * `georel=disjoint`: not intersected with a geometry.
 
+The header `Fiware-Service: tourguide` must be added to every request, so that the proper tenant is specified.
 
  For example, to query for all the restaurants within 13 km of Vitoria-Gasteiz
  city center (identified by GPS coordinates `42.846718`, `-2.671635`)

--- a/doc/development-context-aware-applications/v2/how-to-subscribe-to-changes-on-context-information.md
+++ b/doc/development-context-aware-applications/v2/how-to-subscribe-to-changes-on-context-information.md
@@ -11,6 +11,16 @@ gets notified (in order to recalculate restaurant average rating and
 publish it back in the Context Broker GE).
 
     POST <cb_host>:<cb_port>/v2/subscriptions 
+        
+    Headers:
+
+    {
+      'Content-Type':     'application/json',
+      'Fiware-Service':   'tourguide'
+    }
+
+    Payload:
+
     {
       "description": "Update average rating",
       "subject": {
@@ -46,6 +56,16 @@ average ratings of a given restaurant. This may be useful for restaurant
 owners in order to know how their restaurants score is evolving.
 
     POST <cb_host>:<cb_port>/v2/subscriptions
+        
+    Headers:
+
+    {
+      'Content-Type':     'application/json',
+      'Fiware-Service':   'tourguide'
+    }
+
+    Payload:
+
     {
       "description": "Get aggregateRating for Elizalde",
       "subject": {

--- a/doc/development-context-aware-applications/v2/how-to-update-and-query-context-information.md
+++ b/doc/development-context-aware-applications/v2/how-to-update-and-query-context-information.md
@@ -19,7 +19,7 @@ of restaurants.
 
 Entities that would be relevant to the NiceEating application are of
 type Restaurant, Client and Review. 
-In this guide, the restaurant Elizalde is used as an example. In order to get its id for perform the different requests, we can use:
+In this guide, the restaurant Elizalde is used as an example. In order to get its id for perform the different requests, we can use (with extra headers `Fiware-Service: tourguide`):
 
     GET <cb_host>:<cb_port>/v2/entities?type=Restaurant&q=name==Elizalde&attrs=name&options=keyValues 
     
@@ -36,6 +36,16 @@ When a given user reviews a restaurant (e.g. in a scale from 0 to 5, “Client12
 following HTTP request :
 
     POST <cb_host>:<cb_port>/v2/entities?options=keyValues
+        
+    Headers:
+
+    {
+      'Content-Type':     'application/json',
+      'Fiware-Service':   'tourguide'
+    }
+
+    Payload:
+
     {
       "type": "Review",
       "id": "review-Elizalde-34",
@@ -51,6 +61,16 @@ which (playing also the role of Context Producer) **updates** the
 Restaurant entity accordingly:
 
     PUT <cb_host>:<cb_port>/v2/entities/0115206c51f60b48b77e4c937835795c33bb953f/attrs/aggregateRating/value
+        
+    Headers:
+
+    {
+      'Content-Type':     'application/json',
+      'Fiware-Service':   'tourguide'
+    }
+
+    Payload:
+
     {
       "reviewCount": 2,
       "ratingValue": 4
@@ -60,7 +80,7 @@ Also, the user can get the information of a given Restaurant using
 the smartphone application. In that case the application works as
 Context Consumer, **querying** the Restaurant entity. For example, to get
 the aggregateRating attribute, the client application could query for
-it in the following way:
+it in the following way (with extra headers `Fiware-Service: tourguide`):
 
     GET <cb_host>:<cb_port>/v2/entities/0115206c51f60b48b77e4c937835795c33bb953f/attrs/aggregateRating/value
     
@@ -70,7 +90,7 @@ it in the following way:
     }
 
 You can also obtain the values of all attributes of the "Elizalde"
-restaurant in a single shot:
+restaurant in a single shot (with extra headers `Fiware-Service: tourguide`):
 
     GET <cb_host>:<cb_port>/v2/entities/0115206c51f60b48b77e4c937835795c33bb953f
     
@@ -145,7 +165,7 @@ restaurant in a single shot:
 
 
 Alternatively, if you want to get only attribute values, you can use the `keyValues` parameter, in the
-following way:
+following way (with extra headers `Fiware-Service: tourguide`):
 
     GET <cb_host>:<cb_port>/v2/entities/0115206c51f60b48b77e4c937835795c33bb953f?options=keyValues    
     
@@ -172,7 +192,7 @@ following way:
     }
 
 
-Finally, the application can query entities by attribute content. For example, to get all restaurants with capacity equal or greater than 50 the next request can be used:
+Finally, the application can query entities by attribute content. For example, to get all restaurants with capacity equal or greater than 50 the next request can be used (with extra headers `Fiware-Service: tourguide`):
 
     GET <cb_host>:<cb_port>/v2/entities?type=Restaurant&q=capacity>=50&options=keyValues 
     


### PR DESCRIPTION
This PR indicates that the `fiware-service: tourguide` header should be added to every request.

A compiled version of the documentation with this PR can be consulted at http://testfiwaretour.readthedocs.io/en/content-orion_add_fiware-service_header/development-context-aware-applications/introduction/
